### PR TITLE
MainPage View (SeongGeun)

### DIFF
--- a/DragDrop/DragDrop/View/MainPage.swift
+++ b/DragDrop/DragDrop/View/MainPage.swift
@@ -11,10 +11,24 @@ import SwiftData
 let screenWidth = UIScreen.main.bounds.width
 let screenHeight = UIScreen.main.bounds.height
 
+struct MainPageTaskCard: View {
+    var task: Task
+    var body: some View {
+        HStack {
+            Image(systemName: "line.3.horizontal")
+                .padding(.leading, 10)
+            Text(task.name)
+            Spacer()
+        }
+        .frame(width: screenWidth * 0.8, height: screenHeight * 0.065)
+        .background(Color.white)
+    }
+}
+
 struct MainPage: View {
     //@Query private var tasks: [Task]
     
-    var tasks: [Task] = [Task(name: "Vision Pro 3D Modeling", category: "iOS", isPinned: false, isDone: false), Task(name: "iOS", category: "iOS", isPinned: false, isDone: false), Task(name: "iOS", category: "iOS", isPinned: false, isDone: false)]
+    var tasks: [Task] = [Task(name: "Vision Pro 3D Modeling", category: "iOS", isPinned: false, isDone: false), Task(name: "iOS", category: "iOS", isPinned: false, isDone: false)]
     
     let today = Date().formatted(.iso8601.year().month().day())
     
@@ -45,9 +59,10 @@ struct MainPage: View {
         NavigationView {
             List {
                 ForEach(tasks) { task in
-                    // TaskCard UI 수정 가능하면 맞출 예정
-                    TaskCard(task: task)
+                    // TaskCard code 논의 필요
+                    MainPageTaskCard(task: task)
                         .listRowBackground(Color.clear)
+                        .cornerRadius(10)
                         .frame(width: screenWidth * 0.8)
                 }
                 .listRowSeparator(.hidden)
@@ -63,7 +78,6 @@ struct MainPage: View {
                 }
             }
         }
-        
     }
     
     private func addTask() {

--- a/DragDrop/DragDrop/View/MainPage.swift
+++ b/DragDrop/DragDrop/View/MainPage.swift
@@ -14,14 +14,14 @@ let screenHeight = UIScreen.main.bounds.height
 struct MainPageTaskCard: View {
     var task: Task
     var body: some View {
-        HStack {
+        HStack(spacing: 10) {
             Image(systemName: "line.3.horizontal")
-                .padding(.leading, 10)
             Text(task.name)
                 .font(.system(size: 14))
             Spacer()
         }
-        .frame(width: screenWidth * 0.8, height: screenHeight * 0.065)
+        .padding()
+        .frame(width: screenWidth * 0.8, height: 50)
         .background(Color.white)
     }
 }
@@ -34,51 +34,51 @@ struct MainPage: View {
     let today = Date().formatted(.iso8601.year().month().day())
     
     var body: some View {
-        ZStack {
-            VStack(spacing: 5) {
-                Text("Today is")
-                    .foregroundStyle(Color.gray)
-                Text(today)
-                    .font(.system(size: 24, weight: .semibold))
-            }
-            .padding()
-            
-            VStack {
-                Menu {
-                    Button("환경설정", action: {})
-                    Button("로그아웃", action: {})
-                } label: {
-                    Image(systemName: "line.horizontal.3")
-                        .foregroundStyle(Color.black)
-                        .font(.system(size: 19))
-                }
-            }
-            // 이걸 어떻게 위치를 잡을 지 항상 고민
-            .offset(x: screenWidth * 0.4, y: screenHeight * -0.03)
-        }
         
         NavigationView {
-            List {
-                ForEach(tasks) { task in
-                    // TaskCard code 논의 필요
-                    MainPageTaskCard(task: task)
-                        .listRowBackground(Color.clear)
-                        .cornerRadius(10)
-                        .frame(width: screenWidth * 0.8)
-                }
-                .listRowSeparator(.hidden)
+            VStack {
+                
             }
-            .cornerRadius(10)
-            .padding(.horizontal)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                        .padding(.trailing, 10)
-                        .font(.system(size: 14))
-                        .foregroundStyle(Color.gray)
+                ToolbarItem(placement: .topBarTrailing) {
+                    Image(systemName: "line.3.horizontal")
+                        .foregroundStyle(Color.black)
+                        .font(.system(size: 19, weight: .semibold))
                 }
             }
         }
+        .frame(height: 25)
+        
+        VStack(spacing: 5) {
+            Text("Today is")
+                .foregroundStyle(Color.gray)
+            Text(today)
+                .font(.system(size: 24, weight: .semibold))
+        }
+        .padding()
+        .padding(.top, 0)
+        
+        
+        HStack(alignment: .center) {
+            Spacer()
+            VStack(alignment: .trailing) {
+                EditButton()
+            }
+            .foregroundStyle(Color.gray)
+        }
+        .padding(.trailing, 20)
+        
+        List {
+            ForEach(tasks) { task in
+                // TaskCard code 논의 필요
+                MainPageTaskCard(task: task)
+                    .cornerRadius(10)
+                    .listRowBackground(Color.clear)
+            }
+            .listRowSeparator(.hidden)
+        }
+        .cornerRadius(10)
+        .padding(.horizontal)
     }
     
     private func addTask() {
@@ -88,8 +88,10 @@ struct MainPage: View {
     private func deleteTask() {
         
     }
-    
 }
+
+
+
 
 #Preview {
     MainPage()

--- a/DragDrop/DragDrop/View/MainPage.swift
+++ b/DragDrop/DragDrop/View/MainPage.swift
@@ -18,6 +18,7 @@ struct MainPageTaskCard: View {
             Image(systemName: "line.3.horizontal")
                 .padding(.leading, 10)
             Text(task.name)
+                .font(.system(size: 14))
             Spacer()
         }
         .frame(width: screenWidth * 0.8, height: screenHeight * 0.065)
@@ -49,7 +50,7 @@ struct MainPage: View {
                 } label: {
                     Image(systemName: "line.horizontal.3")
                         .foregroundStyle(Color.black)
-                        .font(.system(size: 20))
+                        .font(.system(size: 19))
                 }
             }
             // 이걸 어떻게 위치를 잡을 지 항상 고민
@@ -73,7 +74,7 @@ struct MainPage: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     EditButton()
                         .padding(.trailing, 10)
-                        .font(.system(size: 15))
+                        .font(.system(size: 14))
                         .foregroundStyle(Color.gray)
                 }
             }

--- a/DragDrop/DragDrop/View/MainPage.swift
+++ b/DragDrop/DragDrop/View/MainPage.swift
@@ -8,22 +8,58 @@
 import SwiftUI
 import SwiftData
 
-struct MainPage: View {
-    @Query private var tasks: [Task]
+let screenWidth = UIScreen.main.bounds.width
+let screenHeight = UIScreen.main.bounds.height
 
+struct MainPage: View {
+    //@Query private var tasks: [Task]
+    
+    var tasks: [Task] = [Task(name: "Vision Pro 3D Modeling", category: "iOS", isPinned: false, isDone: false), Task(name: "iOS", category: "iOS", isPinned: false, isDone: false), Task(name: "iOS", category: "iOS", isPinned: false, isDone: false)]
+    
+    let today = Date().formatted(.iso8601.year().month().day())
+    
     var body: some View {
-        List {
-            ForEach(tasks) { task in
-                TaskCard(task: task)
+        ZStack {
+            VStack(spacing: 5) {
+                Text("Today is")
+                    .foregroundStyle(Color.gray)
+                Text(today)
+                    .font(.system(size: 24, weight: .semibold))
             }
+            .padding()
+            
+            VStack {
+                Menu {
+                    Button("환경설정", action: {})
+                    Button("로그아웃", action: {})
+                } label: {
+                    Image(systemName: "line.horizontal.3")
+                        .foregroundStyle(Color.black)
+                        .font(.system(size: 20))
+                }
+            }
+            // 이걸 어떻게 위치를 잡을 지 항상 고민
+            .offset(x: screenWidth * 0.4, y: screenHeight * -0.03)
+        }
+        
+        NavigationView {
+            List {
+                ForEach(tasks) { task in
+                    // TaskCard UI 수정 가능하면 맞출 예정
+                    TaskCard(task: task)
+                        .listRowBackground(Color.clear)
+                        .frame(width: screenWidth * 0.8)
+                }
+                .listRowSeparator(.hidden)
+            }
+            .cornerRadius(10)
+            .padding(.horizontal)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     EditButton()
-                }
-                ToolbarItem {
-                    Button(action: addTask) {
-                        Label("Add Item", systemImage: "plus")
-                    }
+                        .padding(.trailing, 10)
+                        .font(.system(size: 15))
+                        .foregroundStyle(Color.gray)
                 }
             }
         }
@@ -37,7 +73,7 @@ struct MainPage: View {
     private func deleteTask() {
         
     }
-
+    
 }
 
 #Preview {


### PR DESCRIPTION
### 구현할 화면
<img width="241" alt="image" src="https://github.com/gdsc-konkuk/iOS-DragDrop/assets/117553364/167c2af6-3788-4fe1-9b77-676d11fb951d">

#### 참고할점
- 주석으로 첨부했습니다.
- 추가로, TaskCard View에 대한 논의를 한 뒤에 마저 수정해야 할 거 같습니다. (우선은, MainPage.swift 내에 따로 View를 생성했습니다)
- 버튼을 눌렀을 때, 어떻게 메뉴들이 출력되는 지 정해지지 않았다고 판단해 Menu를 이용해서 간단하게 구현했습니다.
- <U>글씨 크기 수정해야합니다.</U>
- NavigationView로 한 거는 저 화면을 통해서 타고 들어가는 화면이 있다고 판단하여 사용했습니다.
- 이때, NavigationView는 아래로 스와이프 했을 때, iOS 15 이상에서 도입된 "scroll edge appearance" 때문이라고 합니다.

### 실행화면


https://github.com/gdsc-konkuk/iOS-DragDrop/assets/117553364/37eda908-b032-44fb-9f50-6c922b5d13da


